### PR TITLE
🔀 :: (#14) 캘린더 리프레시 버그 및 잔버그 수정

### DIFF
--- a/Timery/Timery.xcodeproj/project.pbxproj
+++ b/Timery/Timery.xcodeproj/project.pbxproj
@@ -1850,9 +1850,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = 235C2RVZ7L;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 235C2RVZ7L;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Timery/SupportingFiles/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1865,10 +1867,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = TeamSB.Timery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Timery.jo;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -1884,9 +1887,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = 235C2RVZ7L;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 235C2RVZ7L;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Timery/SupportingFiles/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1899,10 +1904,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = TeamSB.Timery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Timery.jo;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;

--- a/Timery/Timery/Source/Scene/Analyze/ViewModel/AnalyzeViewModel.swift
+++ b/Timery/Timery/Source/Scene/Analyze/ViewModel/AnalyzeViewModel.swift
@@ -34,7 +34,9 @@ class AnalyzeViewModel: ViewModelType {
                 switch res {
                 case .SUCCEED:
                     guard var resultData = data else { return }
-                    resultData.focusResponses.sort(by: { $0.title != "기타" && $0.sum > $1.sum })
+                    resultData.focusResponses.sort(by: {
+                        return $0.title != "기타" && $1.title != "기타" ? $0.sum > $1.sum : $0.title != "기타"
+                    })
                     analysisData.accept(resultData)
                 default:
                     print(res.errorMessage)

--- a/Timery/Timery/Source/Scene/Calender/ViewController/CalendarViewController.swift
+++ b/Timery/Timery/Source/Scene/Calender/ViewController/CalendarViewController.swift
@@ -20,6 +20,7 @@ class CalendarViewController: UIViewController {
     private let topView = UIVisualEffectView(effect: UIBlurEffect(style: .extraLight)).then {
         $0.layer.opacity = 0
     }
+
     private let topShadowView = UIView().then {
         $0.backgroundColor = .whiteElevated3
         $0.layer.opacity = 0
@@ -112,9 +113,9 @@ class CalendarViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        calendarView.select(Date())
+        guard let selectDate = calendarView.selectedDate else { return }
         getCalendarRecordRelay.accept(Date().toString(to: "yyyy-MM"))
-        selectCalendarRelay.accept(Date().toString(to: "yyyy-MM-dd"))
+        selectCalendarRelay.accept(selectDate.toString(to: "yyyy-MM-dd"))
         timeLineStackView.removeAll()
     }
 }
@@ -303,7 +304,7 @@ extension CalendarViewController {
             $0.centerY.equalTo(monthTitleLabel)
         }
         calendarView.snp.makeConstraints {
-            $0.height.equalTo(600)
+            $0.height.equalTo(580)
             $0.left.right.equalToSuperview().inset(20)
             $0.top.equalToSuperview().offset(70)
         }
@@ -351,6 +352,7 @@ extension CalendarViewController {
     }
 
     private func settingCalendar() {
+        calendarView.select(Date())
         calendarView.appearance.titleDefaultColor = .grayDarken1
         calendarView.appearance.titleFont = .miniTitle3Medium
         calendarView.appearance.headerMinimumDissolvedAlpha = 0.0

--- a/Timery/Timery/Source/Scene/Calender/ViewController/CalendarViewController.swift
+++ b/Timery/Timery/Source/Scene/Calender/ViewController/CalendarViewController.swift
@@ -116,14 +116,12 @@ class CalendarViewController: UIViewController {
         guard let selectDate = calendarView.selectedDate else { return }
         getCalendarRecordRelay.accept(Date().toString(to: "yyyy-MM"))
         selectCalendarRelay.accept(selectDate.toString(to: "yyyy-MM-dd"))
-        timeLineStackView.removeAll()
     }
 }
 
 extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         selectCalendarRelay.accept(date.toString(to: "yyyy-MM-dd"))
-        timeLineStackView.removeAll()
     }
     // 최대 날짜
     func maximumDate(for calendar: FSCalendar) -> Date {
@@ -215,8 +213,11 @@ extension CalendarViewController {
             })
             .disposed(by: dispoesBag)
 
-        output.isHiddenEmptyLable.asObservable()
-            .bind(to: emptyDataLable.rx.isHidden)
+        output.isHiddenEmptyLable
+            .drive(with: self, onNext: { owner, status in
+                owner.timeLineStackView.removeAll()
+                owner.emptyDataLable.isHidden = status
+            })
             .disposed(by: dispoesBag)
 
         output.calendarTimeData.asObservable()

--- a/Timery/Timery/Source/Scene/RecordDetail/ViewController/RecordDetailViewController.swift
+++ b/Timery/Timery/Source/Scene/RecordDetail/ViewController/RecordDetailViewController.swift
@@ -141,7 +141,7 @@ final class RecordDetailViewController: BaseViewController<RecordDetailViewModel
         startRecordButton.rx.tapGesture()
             .when(.recognized)
             .bind(with: self) { owner, _ in
-                owner.navigationController?.popViewControllerWithCompletion(animated: true) {
+                owner.navigationController?.popViewControllerWithCompletion(animated: false) {
                     NotificationCenter.default.post(name: .selectedTabbarIndex, object: 0)
                 }
             }

--- a/Timery/Timery/Source/Scene/Timer/ViewController/TimerHeaderView.swift
+++ b/Timery/Timery/Source/Scene/Timer/ViewController/TimerHeaderView.swift
@@ -68,7 +68,7 @@ extension TimerHeaderView {
         }
         self.snp.makeConstraints {
             $0.width.equalToSuperview()
-            $0.bottom.equalTo(timerTimeLabel).offset(51)
+            $0.bottom.equalTo(timerTimeLabel).offset(48)
         }
     }
 }


### PR DESCRIPTION
## 개요
> 캘린더 뷰의 갱신이 오늘로만 되던 버그 수정

## 고친부분 
- 캘린더 뷰의 갱신 날자를 마지막으로 선택한 날자로 갱신 하도록 수정
- 캘린더 갱신 로직 수정
- 여러 잔버그 수정

https://github.com/Team-SB-2/SB-iOS/assets/80248855/44df4d21-02bb-4caa-8e1d-3fd098cdc8d2

close #14 